### PR TITLE
5.x – Support GoogleAds v19

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class MyClass
 }
 ```
 
-You may then call any of the methods found on the wrapped [Google Ads Client](https://github.com/googleads/google-ads-php/blob/main/src/Google/Ads/GoogleAds/Lib/V8/GoogleAdsClient.php)
+You may then call any of the methods found on the wrapped [Google Ads Client](https://github.com/googleads/google-ads-php/blob/main/src/Google/Ads/GoogleAds/Lib/V13/GoogleAdsClient.php)
 
 ```php
 // As yourself
@@ -86,7 +86,7 @@ $service = $this->googleAds->getCampaignServiceClient();
 ## Versioning
 PHP supported version: `^8.0`
 
-Google Ads PHP SDK versions: `^17.0` [(V11)](https://github.com/googleads/google-ads-php/tree/main/src/Google/Ads/GoogleAds/V11)
+Google Ads PHP SDK versions: `^19.0` ([V12](https://github.com/googleads/google-ads-php/tree/main/src/Google/Ads/GoogleAds/V12), [V13](https://github.com/googleads/google-ads-php/tree/main/src/Google/Ads/GoogleAds/V13))
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,22 @@ Then publish the config file:
 php artisan vendor:publish --provider="JoelButcher\LaravelGoogleAds\ServiceProvider"
 ```
 
-Ensure the following .env variables are set:
+Update your services.php config file with the following
 
-```
-GOOGLE_CLIENT_ID=""
-GOOGLE_CLIENT_SECRET=""
-GOOGLE_DEVELOPER_TOKEN=""
-GOOGLE_LOGIN_CUSTOMER_ID=""
+```php
+<?php
+
+return [
+    'google' => [
+        'client_id' => env('GOOGLE_CLIENT_ID'),
+        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+    ],
+    
+    'google_ads' => [
+        'developer_token' => env('GOOGLE_ADS_DEVELOPER_TOKEN'),
+        'sdk_version' => env('GOOGLE_ADS_VERSION'),
+    ],
+];
 ```
 
 ## Usage
@@ -75,22 +84,18 @@ $service = $this->googleAds->getCampaignServiceClient();
 ```
 
 ## Versioning
-PHP supported version: `^7.3|^8.0`
+PHP supported version: `^8.0`
 
-Google Ads PHP SDK versions: `^11.0` [(V9)](https://github.com/googleads/google-ads-php/tree/main/src/Google/Ads/GoogleAds/V9)
-
-## Changelog
-
-Check out the [CHANGELOG](CHANGELOG.md) in this repository for all the recent changes.
+Google Ads PHP SDK versions: `^17.0` [(V11)](https://github.com/googleads/google-ads-php/tree/main/src/Google/Ads/GoogleAds/V11)
 
 ## Maintainers
 
-Developed and maintained by [Joel Butcher](https://joelbutcher.co.uk)
+Developed and maintained by [Joel Butcher](https://joelbutcher.dev)
 
 ## Credits
 
-You can view all contributers [here](https://github.com/joelbutcher/laravel-googleads/graphs/contributors)
+You can view all contributors [here](https://github.com/joelbutcher/laravel-googleads/graphs/contributors)
 
 ## License
 
-This pacakge is open-sourced software licensed under the [MIT license](LICENSE.md).
+This package is open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "joelbutcher/googleads": "^5.0.0"
+        "joelbutcher/googleads": "^6.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "joelbutcher/googleads": "^3.0.0"
+        "php": "^8.0",
+        "joelbutcher/googleads": "^4.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -23,9 +23,6 @@
         }
     },
     "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
-        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "joelbutcher/googleads": "^4.0.0"
+        "joelbutcher/googleads": "^5.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/laravel-googleads.php
+++ b/config/laravel-googleads.php
@@ -1,8 +1,0 @@
-<?php
-
-return [
-    'client_id' => env('GOOGLE_CLIENT_ID'),
-    'client_secret' => env('GOOGLE_CLIENT_SECRET'),
-    'developer_token' => env('GOOGLE_DEVELOPER_TOKEN'),
-    'login_customer_id' => env('GOOGLE_LOGIN_CUSTOMER_ID'),
-];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,24 +15,12 @@ class ServiceProvider extends BaseServiceProvider
     public function register()
     {
         $this->app->bind(GoogleAds::class, function () {
-            return new GoogleAds([
-                'client_id' => config('laravel-googleads.client_id'),
-                'client_secret' => config('laravel-googleads.client_secret'),
-                'developer_token' => config('laravel-googleads.developer_token'),
-                'login_customer_id' => (int) config('laravel-googleads.login_customer_id'),
-            ]);
+            return new GoogleAds(
+                clientId: config('services.google.client_id'),
+                clientSecret: config('services.google.client_secret'),
+                developerToken: config('services.google_ads.developer_token'),
+                sdkVersion: config('services.google_ads.sdk_version'),
+            );
         });
-    }
-
-    /**
-     * Bootstrap services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->publishes([
-            __DIR__.'/../config/laravel-googleads.php' => config_path('laravel-googleads.php'),
-        ], 'laravel-googleads-config');
     }
 }


### PR DESCRIPTION
## TL;DR
Updates the minimum version of [joelbutcher/googleads](http://github.com/joelbutcher/googleads) to add support for the V19 SDK

## Description
- Updates `composer.json` to target joelbutcher/googleads:^6.0.0
- Updates SDK references in `README.md` to target V12 and V13 